### PR TITLE
fix: SearchQuerySetMixin for nested search

### DIFF
--- a/belt/managers.py
+++ b/belt/managers.py
@@ -14,5 +14,5 @@ class SearchQuerySetMixin:
             fields = []
         conditions = [Q(**{f"{field}__icontains": query}) for field in fields]
         if conditions:
-            return self.filter(reduce(lambda x, y: x | y, conditions))
+            return self.filter(reduce(lambda x, y: x | y, conditions)).distinct()
         return self.none()


### PR DESCRIPTION
Make sure that the filtered results from the `search` mixing are unique.
Nested search fields such as `SEARCH_FIELDS = ["product__name", "product__categories__name"]` would return repeated objects.